### PR TITLE
Fix network backup

### DIFF
--- a/playbooks/network_backup.yml
+++ b/playbooks/network_backup.yml
@@ -62,6 +62,7 @@
         survey_enabled: true
         survey_spec: "{{ lookup('template', '{{ playbook_dir }}/../network_setup/templates/backup.j2') }}"
         validate_certs: no
+        execution_environment: "Default execution environment"
       run_once: true
 
     # - name: create restore job template

--- a/roles/backup/tasks/eos.yml
+++ b/roles/backup/tasks/eos.yml
@@ -3,5 +3,5 @@
     backup: true
     backup_options:
       dir_path: /tmp/
-      filename: "{{ inventory_hostname }}"      
+      filename: "{{ inventory_hostname }}.txt"
   register: config_output

--- a/roles/backup/tasks/ios.yml
+++ b/roles/backup/tasks/ios.yml
@@ -10,7 +10,7 @@
 # This task removes the Current configuration... from the top of IOS routers show run
 - name: remove non config lines - regexp
   lineinfile:
-    path: "{{ config_output.backup_path }}.txt"
+    path: "{{ config_output.backup_path }}"
     line: "Building configuration..."
     state: absent
   delegate_to: localhost

--- a/roles/backup/tasks/junos.yml
+++ b/roles/backup/tasks/junos.yml
@@ -10,5 +10,5 @@
     backup: true
     backup_options:
       dir_path: /tmp/
-      filename: "{{ inventory_hostname }}"      
+      filename: "{{ inventory_hostname }}.txt"
   register: config_output

--- a/roles/restore/tasks/eos.yml
+++ b/roles/restore/tasks/eos.yml
@@ -1,5 +1,5 @@
 - debug:
-    msg: "restoring from /backup/{{rollback_date}}/{{inventory_hostname}}"
+    msg: "restoring from /backup/{{rollback_date}}/{{inventory_hostname}}.txt"
 
 - name: restore the config
   arista.eos.eos_config:

--- a/roles/restore/tasks/eos.yml
+++ b/roles/restore/tasks/eos.yml
@@ -4,7 +4,7 @@
 - name: restore the config
   arista.eos.eos_config:
     replace: config
-    src: "/backup/{{rollback_date}}/{{inventory_hostname}}"
+    src: "/backup/{{rollback_date}}/{{inventory_hostname}}.txt"
 
 - name: print to terminal window
   debug:

--- a/roles/restore/tasks/eos.yml
+++ b/roles/restore/tasks/eos.yml
@@ -1,11 +1,11 @@
 - debug:
-    msg: "restoring from /backup/{{rollback_date}}/{{inventory_hostname}}.txt"
+    msg: "restoring from /backup/{{ rollback_date }}/{{ inventory_hostname }}.txt"
 
 - name: restore the config
   arista.eos.eos_config:
     replace: config
-    src: "/backup/{{rollback_date}}/{{inventory_hostname}}.txt"
+    src: "/tmp/{{ rollback_date }}/{{ inventory_hostname }}.txt"
 
 - name: print to terminal window
   debug:
-    msg: "Restore is complete for device {{inventory_hostname}} is set to {{rollback_date}} timestamp"
+    msg: "Restore is complete for device {{ inventory_hostname }} is set to {{ rollback_date }} timestamp"

--- a/roles/restore/tasks/eos.yml
+++ b/roles/restore/tasks/eos.yml
@@ -2,7 +2,7 @@
     msg: "restoring from /backup/{{rollback_date}}/{{inventory_hostname}}"
 
 - name: restore the config
-  arista.eos.config:
+  arista.eos.eos_config:
     replace: config
     src: "/backup/{{rollback_date}}/{{inventory_hostname}}"
 

--- a/roles/restore/tasks/junos.yml
+++ b/roles/restore/tasks/junos.yml
@@ -1,5 +1,5 @@
 - debug:
-    msg: "restoring from /backup/{{rollback_date}}/{{inventory_hostname}}"
+    msg: "restoring from /backup/{{rollback_date}}/{{inventory_hostname}}.txt"
 
 - name: restore the config
   junipernetworks.junos.junos_config:

--- a/roles/restore/tasks/junos.yml
+++ b/roles/restore/tasks/junos.yml
@@ -2,7 +2,7 @@
     msg: "restoring from /backup/{{rollback_date}}/{{inventory_hostname}}"
 
 - name: restore the config
-  junipernetworks.junos.config:
+  junipernetworks.junos.junos_config:
     update: replace
     src: "/backup/{{rollback_date}}/{{inventory_hostname}}"
 

--- a/roles/restore/tasks/junos.yml
+++ b/roles/restore/tasks/junos.yml
@@ -1,11 +1,11 @@
 - debug:
-    msg: "restoring from /backup/{{rollback_date}}/{{inventory_hostname}}.txt"
+    msg: "restoring from /backup/{{ rollback_date }}/{{ inventory_hostname }}.txt"
 
 - name: restore the config
   junipernetworks.junos.junos_config:
     update: replace
-    src: "/backup/{{rollback_date}}/{{inventory_hostname}}.txt"
+    src: "/tmp/{{ rollback_date }}/{{ inventory_hostname }}.txt"
 
 - name: print to terminal window
   debug:
-    msg: "Restore is complete for device {{inventory_hostname}} is set to {{rollback_date}} timestamp"
+    msg: "Restore is complete for device {{ inventory_hostname }} is set to {{ rollback_date }} timestamp"

--- a/roles/restore/tasks/junos.yml
+++ b/roles/restore/tasks/junos.yml
@@ -4,7 +4,7 @@
 - name: restore the config
   junipernetworks.junos.junos_config:
     update: replace
-    src: "/backup/{{rollback_date}}/{{inventory_hostname}}"
+    src: "/backup/{{rollback_date}}/{{inventory_hostname}}.txt"
 
 - name: print to terminal window
   debug:


### PR DESCRIPTION
Network Workshop Ex 9: failure in the network restore

I'm putting this PR here because this is the repo currently used by the project for the network workshop. Please let me know if this is incorrect.

During a run through of the workflow exercise we had what appears to be a spurious issue with the Network-User job (a "database locked" error by ec2-user terminal). This was retried and the job didn't fail again. However, the subsequent network restore job did fail after the network user job failure.

We ran network backup and network restore separately to look into this and found a few errors, the first was a failure of the path for the ios backup job.
- remove non config lines - regexp: path variable has an extra .txt 
  "changed": false,
  "msg": "file not present",
  "invocation": {
    "module_args": {
      "path": "/tmp/rtr1.txt.txt",
      "line": "Building configuration...",
      "state": "absent",

After fixing that, we looked at the restore job output and found that the loop over the backup files was looking for .txt extensions.
- playbooks/network_restore.yml: retreive configuration from backup-server to execution environment: the src value is expected to have a txt extension for all device types (ios, eos, junos) but only ios has that from the backup roles
  TASK [retreive configuration from backup-server to execution environment] ******
  changed: [rtr1 -> backup-server]
  fatal: [rtr3 -> backup-server]: FAILED! => {"changed": false, "msg": "file not found: /backup/2022-01-11-20-41/rtr3.txt"}
  fatal: [rtr4 -> backup-server]: FAILED! => {"changed": false, "msg": "file not found: /backup/2022-01-11-20-41/rtr4.txt"}
  fatal: [rtr2 -> backup-server]: FAILED! => {"changed": false, "msg": "file not found: /backup/2022-01-11-20-41/rtr2.txt"}

After that was fixed we found that the module name was not resolving for the restore. That turned out to be the exec env set in the restore job template (it was not set and so was defaulting to the 2.9 env, which did not include those collections).
- playbooks/network_restore.yml: load platform module for restore: 
  couldn't resolve module/action 'cisco.ios.config'.
  Also failed for arista.eos.config and junipernetworks.junos.config

After fixing that we found path issues again and changed /backup/ to /tmp/
- playbooks/network_restore.yml: restore the config:
  TASK [../roles/restore : restore the config] ***********************************
  fatal: [rtr2]: FAILED! => {"changed": false, "msg": "path specified in src not found"}
  fatal: [rtr4]: FAILED! => {"changed": false, "msg": "path specified in src not found"}
  Also failed for junos

Rechecked with separate runs of backup and restore.
